### PR TITLE
Add API call functionality

### DIFF
--- a/Lexical/Core/Editor.swift
+++ b/Lexical/Core/Editor.swift
@@ -926,6 +926,30 @@ public class Editor: NSObject {
 
     return self.editorState
   }
+
+  // Add a new method `fetchDataFromAPI` to handle API calls
+  public func fetchDataFromAPI(urlString: String, completion: @escaping (Result<Data, Error>) -> Void) {
+    guard let url = URL(string: urlString) else {
+      completion(.failure(LexicalError.internal("Invalid URL")))
+      return
+    }
+
+    let task = URLSession.shared.dataTask(with: url) { data, response, error in
+      if let error = error {
+        completion(.failure(error))
+        return
+      }
+
+      guard let data = data else {
+        completion(.failure(LexicalError.internal("No data received")))
+        return
+      }
+
+      completion(.success(data))
+    }
+
+    task.resume()
+  }
 }
 
 internal enum NativeSelectionModificationType {

--- a/Lexical/Core/EditorState.swift
+++ b/Lexical/Core/EditorState.swift
@@ -17,6 +17,7 @@ public class EditorState: NSObject {
 
   internal var nodeMap: [NodeKey: Node] = [:]
   public var selection: BaseSelection?
+  public var apiResponseData: Data? // New property to store API response data
 
   override init() {
     let rootNode = RootNode()
@@ -25,6 +26,7 @@ public class EditorState: NSObject {
 
   init(_ editorState: EditorState) {
     nodeMap = editorState.nodeMap
+    apiResponseData = editorState.apiResponseData // Include the new property in the clone
   }
 
   /// Returns the root node for this EditorState, if one is set.

--- a/Lexical/LexicalView/LexicalView.swift
+++ b/Lexical/LexicalView/LexicalView.swift
@@ -19,6 +19,7 @@ public protocol LexicalViewDelegate: NSObjectProtocol {
   func textViewDidEndEditing(textView: LexicalView)
   func textViewShouldChangeText(_ textView: LexicalView, range: NSRange, replacementText text: String) -> Bool
   func textView(_ textView: LexicalView, shouldInteractWith URL: URL, in selection: RangeSelection?, interaction: UITextItemInteraction) -> Bool
+  func didReceiveAPIResponse(_ response: Data) // New method for handling API responses
 }
 
 public extension LexicalViewDelegate {
@@ -477,6 +478,20 @@ public extension LexicalViewDelegate {
   public func commitAutocompleteSuggestions() {
     textView.inputDelegate?.selectionWillChange(textView)
     textView.inputDelegate?.selectionDidChange(textView)
+  }
+
+  // New method to trigger API call
+  public func triggerAPICall(urlString: String) {
+    editor.fetchDataFromAPI(urlString: urlString) { [weak self] result in
+      switch result {
+      case .success(let data):
+        DispatchQueue.main.async {
+          self?.delegate?.didReceiveAPIResponse(data)
+        }
+      case .failure(let error):
+        print("Error fetching data from API: \(error)")
+      }
+    }
   }
 }
 

--- a/Playground/LexicalPlayground/ViewController.swift
+++ b/Playground/LexicalPlayground/ViewController.swift
@@ -12,7 +12,7 @@ import LexicalLinkPlugin
 import LexicalListPlugin
 import UIKit
 
-class ViewController: UIViewController, UIToolbarDelegate {
+class ViewController: UIViewController, UIToolbarDelegate, LexicalViewDelegate {
 
   var lexicalView: LexicalView?
   weak var toolbar: UIToolbar?
@@ -59,6 +59,12 @@ class ViewController: UIViewController, UIToolbarDelegate {
 
     navigationItem.title = "Lexical"
     setUpExportMenu()
+    
+    // Set the delegate to self
+    lexicalView.delegate = self
+    
+    // Trigger the API call
+    lexicalView.triggerAPICall(urlString: "https://api.example.com/data")
   }
 
   override func viewDidLayoutSubviews() {
@@ -136,5 +142,11 @@ class ViewController: UIViewController, UIToolbarDelegate {
 
   func position(for bar: UIBarPositioning) -> UIBarPosition {
     return .top
+  }
+  
+  // Implement the new LexicalViewDelegate method to handle API responses
+  func didReceiveAPIResponse(_ response: Data) {
+    // Handle the API response data here
+    print("Received API response: \(response)")
   }
 }


### PR DESCRIPTION
Add API call functionality to the `Editor` and `LexicalView` classes.

* **Editor.swift**
  - Add `fetchDataFromAPI` method to handle API calls using `URLSession`.
* **EditorState.swift**
  - Add `apiResponseData` property to store API response data.
  - Update `clone` method to include the new property.
* **LexicalView.swift**
  - Add `triggerAPICall` method to initiate the API call.
  - Update `LexicalViewDelegate` protocol to include `didReceiveAPIResponse` method for handling API responses.
* **ViewController.swift**
  - Implement `didReceiveAPIResponse` method to handle API responses.
  - Set `lexicalView.delegate` to self and trigger the API call.

